### PR TITLE
Addons

### DIFF
--- a/app/items/route.js
+++ b/app/items/route.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  // from ember-arcgis-portal-services
+  itemsService: Ember.inject.service('items-service'),
+
   // changes to these query parameter will cause this route to
   // update the model by calling the "model()" hook again
   queryParams: {
@@ -14,11 +17,9 @@ export default Ember.Route.extend({
   },
 
   // the model hook is used to fetch any data based on route parameters
-  model (/* params */) {
-    // TODO: search for items using the search term and item type
-    return {
-      total: 0,
-      results: []
-    };
+  model (params) {
+    const itemsService = this.get('itemsService');
+    const q = params.q;
+    return itemsService.search({ q });
   }
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,5 +1,3 @@
-@import "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css";
-
 body {
   padding-top: 20px;
   padding-bottom: 20px;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,17 +1,23 @@
 <div class="container">
 
   <!-- navbar -->
-  <nav class="navbar navbar-default">
-    <div class="container-fluid">
+  {{#bs-navbar fluid=true as |navbar|}}
       <div class="navbar-header">
-        <span class="navbar-brand">Ambitious ArcGIS App</span>
+          {{#navbar.toggle}}
+              <span class="sr-only">Toggle navigation</span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+          {{/navbar.toggle}}
+         {{#link-to "index" class="navbar-brand"}}Ambitious ArcGIS App{{/link-to}}
       </div>
-      <ul class="nav navbar-nav">
-        <li>{{#link-to "index" }}Home{{/link-to}}</li>
-        <li>{{#link-to "items" }}Items{{/link-to}}</li>
-      </ul>
-    </div><!--/.container-fluid -->
-  </nav>
+      {{#navbar.content}}
+          {{#navbar.nav as |nav|}}
+              {{#nav.item}}{{#link-to "index"}}Home{{/link-to}}{{/nav.item}}
+              {{#nav.item}}{{#link-to "items" }}Items{{/link-to}}{{/nav.item}}
+          {{/navbar.nav}}
+      {{/navbar.content}}
+  {{/bs-navbar}}
 
   <!-- page content -->
   {{outlet}}

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "ambitious-arcgis-app",
   "dependencies": {
+    "bootstrap": "^3.3.7"
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,6 +20,15 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    torii: {
+      sessionServiceName: 'session',
+      providers: {
+       'arcgis-oauth-bearer': {
+          portalUrl: 'https://www.arcgis.com' //optional - defaults to https://arcgis.com
+        }
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
+    "ember-bootstrap": "1.0.0-alpha.4",
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-babel": "^5.1.7",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
+    "ember-arcgis-portal-services": "0.10.1",
     "ember-bootstrap": "1.0.0-alpha.4",
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
@@ -35,10 +36,13 @@
     "ember-data": "^2.11.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
+    "ember-network": "0.3.1",
     "ember-resolver": "^2.0.3",
     "ember-source": "~2.11.0",
     "ember-welcome-page": "^2.0.2",
-    "loader.js": "^4.0.10"
+    "loader.js": "^4.0.10",
+    "torii": "0.8.1",
+    "torii-provider-arcgis": "0.6.2"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/workshop/3-addons.md
+++ b/workshop/3-addons.md
@@ -1,0 +1,30 @@
+# Addons
+
+http://www.ember-bootstrap.com/#/getting-started
+
+## Add ember-bootstrap
+- stop app (`cmd+C`)
+- `ember install ember-bootstrap`
+- in app/app.css remove `@import "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css";`
+- `ember serve` and visit `localhost:4200` and verify that app looks the same
+- in app/templates/application.hbs replace navbar with:
+
+```hbs
+{{#bs-navbar fluid=true as |navbar|}}
+    <div class="navbar-header">
+        {{#navbar.toggle}}
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        {{/navbar.toggle}}
+       {{#link-to "index" class="navbar-brand"}}Ambitious ArcGIS App{{/link-to}}
+    </div>
+    {{#navbar.content}}
+        {{#navbar.nav as |nav|}}
+            {{#nav.item}}{{#link-to "index"}}Home{{/link-to}}{{/nav.item}}
+            {{#nav.item}}{{#link-to "items" }}Items{{/link-to}}{{/nav.item}}
+        {{/navbar.nav}}
+    {{/navbar.content}}
+{{/bs-navbar}}
+```

--- a/workshop/3-addons.md
+++ b/workshop/3-addons.md
@@ -28,3 +28,37 @@ http://www.ember-bootstrap.com/#/getting-started
     {{/navbar.content}}
 {{/bs-navbar}}
 ```
+
+## Add ember-arcgis-portal-services
+
+- stop app (`cmd+C`)
+- `ember install ember-network`
+- follow instructions here: https://github.com/dbouwman/torii-provider-arcgis#usage
+- `ember install ember-arcgis-portal-services`
+- in config/environment.js add:
+
+```js
+torii: {
+  sessionServiceName: 'session',
+  providers: {
+   'arcgis-oauth-bearer': {
+      portalUrl: 'https://www.arcgis.com'
+    }
+  }
+}
+```
+
+- `ember serve` and visit `localhost:4200`
+- in app/items/route.js inject `itemsService` and replace `model()` hook:
+
+```js
+  // from ember-arcgis-portal-services
+  itemsService: Ember.inject.service('items-service'),
+
+  // the model hook is used to fetch any data based on route parameters
+  model (params) {
+    const itemsService = this.get('itemsService');
+    const q = params.q;
+    return itemsService.search({ q });
+  }
+```


### PR DESCRIPTION
add ember-bootstrap and ember-arcgis-portal-services

Only reason haven't merged this yet is b/c not sure if we want to add more routes/components (such as a `search-results-list-item` component or a `items.item` route under section 2 (components) before adding commits for section 3 (addons) - just to keep order of commits in line w/ sections.
