### PR TITLE
add map integration test

### DIFF
--- a/app/components/extents-map/component.js
+++ b/app/components/extents-map/component.js
@@ -11,10 +11,10 @@ export default Ember.Component.extend({
   didInsertElement () {
     this._super(...arguments);
     const mapService = this.get('mapService');
-    // create a map at this element's DOM node
-    mapService.newMap(this.elementId, config.APP.map.options);
     // show item extents once map loads
     mapService.on('load', this, this.showItemsOnMap);
+    // create a map at this element's DOM node
+    mapService.newMap(this.elementId, config.APP.map.options);
   },
 
   // whenever items change, update the map

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "ember-load-initializers": "^0.6.0",
     "ember-network": "0.3.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.6.0",
+    "ember-sinon-qunit": "1.4.1",
     "ember-source": "~2.11.0",
     "ember-welcome-page": "^2.0.2",
     "loader.js": "^4.0.10",

--- a/tests/integration/components/extents-map/component-test.js
+++ b/tests/integration/components/extents-map/component-test.js
@@ -1,4 +1,5 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { moduleForComponent } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('extents-map', 'Integration | Component | extents map', {
@@ -6,20 +7,14 @@ moduleForComponent('extents-map', 'Integration | Component | extents map', {
 });
 
 test('it renders', function(assert) {
+  const mapService = this.container.lookup('service:map-service');
+  const stub = this.stub(mapService, 'newMap');
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{extents-map}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#extents-map}}
-      template block text
-    {{/extents-map}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  // assert.equal(this.$().text().trim(), '');
+  assert.ok(stub.calledOnce, 'newMap was called once');
 });

--- a/tests/integration/components/extents-map/component-test.js
+++ b/tests/integration/components/extents-map/component-test.js
@@ -7,14 +7,50 @@ moduleForComponent('extents-map', 'Integration | Component | extents map', {
 });
 
 test('it renders', function(assert) {
+  // stub newMap to prevent map from being created
   const mapService = this.container.lookup('service:map-service');
-  const stub = this.stub(mapService, 'newMap');
+  const stub = this.stub(mapService, 'newMap', () => {
+    // simulate the map having been loaded
+    mapService.trigger('load');
+  });
+  // capture the extents passed in, and don't add the to (non-existent) map
+  const refreshGraphicsStub = this.stub(mapService, 'refreshGraphics');
+  // dummy items we'll use for testing
+  const items = [{
+      "title": "Mandatory Water Restrictions",
+      "snippet": "This map shows the area where there are active mandatory water restrictions placed by WSSC",
+      "extent": [
+          [-78.3657, 38.191],
+          [-75.8993, 39.6927]
+      ]
+  }, {
+      "title": "Broward County Water Services",
+      "snippet": "A map of the Water Control Districts, Water Service Areas, and Sewer Service Areas Contacts",
+      "extent": []
+  }];
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('items', items);
 
-  this.render(hbs`{{extents-map}}`);
+  this.render(hbs`{{extents-map items=items}}`);
 
-  // assert.equal(this.$().text().trim(), '');
+  // update the items to triggr a second call to refreshGraphics
+  this.set('items', [{
+      "title": "Canterbury Land and Water Regional Plan",
+      "snippet": "Canterbury Land and Water Regional Plan map layers.",
+      "extent": [
+          [170.1402, -44.3006],
+          [173.8127, -42.7658]
+      ]
+  }]);
+
+  // get the extents that were passed into refreshGraphics
+  const initialExtents = refreshGraphicsStub.getCall(0).args[0];
+  const updatedExtents = refreshGraphicsStub.getCall(1).args[0];
+
+  // assertions
   assert.ok(stub.calledOnce, 'newMap was called once');
+  assert.equal(initialExtents.length, 2, 'got expected initial extents');
+  assert.equal(updatedExtents.length, 1, 'got expected updated extents');
 });

--- a/workshop/5-maps.md
+++ b/workshop/5-maps.md
@@ -103,6 +103,38 @@ export default Ember.Component.extend({
 
 - go to the items route, you should see a map
 
+### Bonus - map component test
+
+Goal: stub the map service so we don't create a map when testing
+
+- `ember install ember-sinon-qunit`
+- run `ember test - s` and filter for "integration"
+- open network tab of test browser and filter for "arcgisonline.com"
+- in tests/integration/component/extents-map/component-test.js replace `import { moduleForComponent, test } from 'ember-qunit';` with:
+
+```js
+import { moduleForComponent } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+```
+
+- replace the contents of the 'it renders' test with:
+
+```js
+// stub the newMap() function so that a map is not constructed
+const mapService = this.container.lookup('service:map-service');
+const stub = this.stub(mapService, 'newMap');
+
+// Set any properties with this.set('myProperty', 'value');
+// Handle any actions with this.on('myAction', function(val) { ... });
+
+this.render(hbs`{{extents-map}}`);
+
+// assert.equal(this.$().text().trim(), '');
+assert.ok(stub.calledOnce, 'newMap was called once');
+```
+
+- network tab should no longer show "arcgisonline.com" requests
+
 ## Showing item extents on the map
 
 ### Logic


### PR DESCRIPTION
added a bonus to map section which installs ember-sinon-quint to out map service methods to prevent creating the actual map during map component tests.
